### PR TITLE
Support entry point from within OrionCmdlineParser

### DIFF
--- a/src/orion/core/io/orion_cmdline_parser.py
+++ b/src/orion/core/io/orion_cmdline_parser.py
@@ -18,7 +18,10 @@ utility functions to build it again as a list or an already formatted string.
 
 from collections import defaultdict, OrderedDict
 import copy
+import errno
+import os
 import re
+import shutil
 
 from orion.core.io.cmdline_parser import CmdlineParser
 from orion.core.io.convert import infer_converter_from_file_type
@@ -51,6 +54,8 @@ class OrionCmdlineParser():
         An OrderedDict obtained by parsing the config file, if one was found.
     priors : OrderedDict
         An OrderedDict obtained from merging `cmd_priors` and `file_priors`.
+    user_script : str
+        File path of the script executed (inferred from parsed commandline)
     config_prefix : str
         Prefix for the configuration file used by the parser to identify it.
     file_config_path : str
@@ -67,7 +72,7 @@ class OrionCmdlineParser():
 
     """
 
-    def __init__(self, config_prefix='config'):
+    def __init__(self, config_prefix='config', allow_non_existing_user_script=False):
         """Create an `OrionCmdlineParser`."""
         self.parser = CmdlineParser()
         self.cmd_priors = OrderedDict()
@@ -77,6 +82,9 @@ class OrionCmdlineParser():
         self.config_prefix = config_prefix
         self.file_config_path = None
         self.converter = None
+
+        self.allow_non_existing_user_script = allow_non_existing_user_script
+        self.user_script = None
 
         # Extraction methods for the file parsing part.
         self._extraction_method = {dict: self._extract_dict,
@@ -126,6 +134,7 @@ class OrionCmdlineParser():
             If a prior inside the commandline and the config file have the same name.
 
         """
+        self.infer_user_script(commandline)
         replaced = self._replace_priors(commandline)
         configuration = self.parser.parse(replaced)
         self._build_priors(configuration)
@@ -134,6 +143,24 @@ class OrionCmdlineParser():
         if duplicated_priors:
             raise ValueError("Conflict: definition of same prior in commandline and config: "
                              "{}".format(duplicated_priors))
+
+    def infer_user_script(self, user_args):
+        """Infer the script name and perform some checks"""
+        if not user_args:
+            return
+
+        # TODO: Parse commandline for any options to python and pick the script filepath properly
+        if user_args[0] == 'python':
+            user_script = user_args[1]
+        else:
+            user_script = user_args[0]
+
+        if (not os.path.exists(user_script) and not shutil.which(user_script) and
+                not self.allow_non_existing_user_script):
+            raise OSError(errno.ENOENT, "The path specified for the script does not exist",
+                          user_script)
+
+        self.user_script = user_script
 
     @property
     def priors(self):

--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -44,8 +44,6 @@ import re
 from scipy.stats import distributions as sp_dists
 
 from orion.algo.space import (Categorical, Fidelity, Integer, Real, Space)
-from orion.core import config as orion_config
-from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 from orion.core.utils.flatten import flatten
 
 
@@ -257,23 +255,6 @@ class SpaceBuilder(object):
 
         self.converter = None
         self.parser = None
-
-    def build_from(self, config):
-        """Build a `Space` object from a configuration.
-
-        Initialize a new parser for this commandline and parse the given config then
-        build a `Space` object from that configuration.
-
-        Returns
-        -------
-        `orion.algo.space.Space`
-            The problem's search space definition.
-
-        """
-        self.parser = OrionCmdlineParser(orion_config.user_script_config)
-        self.parser.parse(config)
-
-        return self.build(self.parser.priors)
 
     def build(self, configuration):
         """Create a definition of the problem's search space.

--- a/src/orion/core/utils/backward.py
+++ b/src/orion/core/utils/backward.py
@@ -14,12 +14,21 @@ import orion.core
 from orion.core.io.orion_cmdline_parser import OrionCmdlineParser
 
 
+def update_user_args(metadata):
+    """Make sure user script is not removed from metadata"""
+    if "user_script" in metadata and metadata["user_script"] not in metadata["user_args"]:
+        metadata["user_args"] = [metadata["user_script"]] + metadata["user_args"]
+
+
 def populate_priors(metadata):
     """Compute parser state and priors based on user_args and populate metadata."""
     if 'user_args' not in metadata:
         return
 
-    parser = OrionCmdlineParser(orion.core.config.user_script_config)
+    update_user_args(metadata)
+
+    parser = OrionCmdlineParser(orion.core.config.user_script_config,
+                                allow_non_existing_user_script=True)
     parser.parse(metadata["user_args"])
     metadata["parser"] = parser.get_state_dict()
     metadata["priors"] = dict(parser.priors)

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -69,8 +69,6 @@ class Consumer(object):
         else:
             self.working_dir = os.path.join(tempfile.gettempdir(), 'orion')
 
-        self.script_path = experiment.metadata['user_script']
-
         self.pacemaker = None
 
     def consume(self, trial):
@@ -186,9 +184,10 @@ class Consumer(object):
 
         return results_file
 
+    # pylint: disable = no-self-use
     def execute_process(self, cmd_args, environ):
         """Facilitate launching a black-box trial."""
-        command = [self.script_path] + cmd_args
+        command = cmd_args
 
         signal.signal(signal.SIGTERM, _handler)
         process = subprocess.Popen(command, env=environ)

--- a/tests/functional/branching/black_box_new.py
+++ b/tests/functional/branching/black_box_new.py
@@ -18,7 +18,7 @@ def execute():
     # 1. Receive inputs as you want
     parser = argparse.ArgumentParser()
     parser.add_argument('-x', type=float, required=True)
-    parser.add_argument('--a-new', type=str, required=True)
+    parser.add_argument('--a-new', type=str)
     inputs = parser.parse_args()
 
     # 2. Perform computations

--- a/tests/functional/branching/test_branching.py
+++ b/tests/functional/branching/test_branching.py
@@ -33,7 +33,8 @@ def init_full_x_full_y(init_full_x):
     name = "full_x"
     branch = "full_x_full_y"
     orion.core.cli.main(
-        ("init_only -n {branch} --branch-from {name} ./black_box_with_y.py "
+        ("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+         "./black_box_with_y.py "
          "-x~uniform(-10,10) "
          "-y~+uniform(-10,10,default_value=1)").format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=1 -y=1".format(branch=branch).split(" "))
@@ -73,7 +74,8 @@ def init_full_x_rename_y_z(init_full_x_full_y):
     """Rename y from full x full y to z"""
     name = "full_x_full_y"
     branch = "full_x_rename_y_z"
-    orion.core.cli.main(("init_only -n {branch} --branch-from {name} ./black_box_with_z.py "
+    orion.core.cli.main(("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+                         "./black_box_with_z.py "
                          "-x~uniform(-10,10) -y~>z -z~uniform(-10,10,default_value=1)"
                          ).format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=4 -z=4".format(branch=branch).split(" "))
@@ -87,7 +89,8 @@ def init_full_x_rename_half_y_half_z(init_full_x_half_y):
     """Rename y from full x half y to z"""
     name = "full_x_half_y"
     branch = "full_x_rename_half_y_half_z"
-    orion.core.cli.main(("init_only -n {branch} --branch-from {name} ./black_box_with_z.py "
+    orion.core.cli.main(("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+                         "./black_box_with_z.py "
                          "-x~uniform(-10,10) -y~>z -z~uniform(0,10,default_value=1)"
                          ).format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=5 -z=5".format(branch=branch).split(" "))
@@ -100,7 +103,8 @@ def init_full_x_rename_half_y_full_z(init_full_x_half_y):
     name = "full_x_half_y"
     branch = "full_x_rename_half_y_full_z"
     orion.core.cli.main(
-        ("init_only -n {branch} --branch-from {name} ./black_box_with_z.py "
+        ("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+         "./black_box_with_z.py "
          "-x~uniform(-10,10) -y~>z "
          "-z~+uniform(-10,10,default_value=1)").format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=6 -z=6".format(branch=branch).split(" "))
@@ -115,7 +119,8 @@ def init_full_x_remove_y(init_full_x_full_y):
     name = "full_x_full_y"
     branch = "full_x_remove_y"
     orion.core.cli.main(
-        ("init_only -n {branch} --branch-from {name} ./black_box.py "
+        ("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+         "./black_box.py "
          "-x~uniform(-10,10) -y~-").format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=7".format(branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=-7".format(branch=branch).split(" "))
@@ -127,7 +132,8 @@ def init_full_x_remove_z(init_full_x_rename_y_z):
     name = "full_x_rename_y_z"
     branch = "full_x_remove_z"
     orion.core.cli.main(
-        ("init_only -n {branch} --branch-from {name} ./black_box.py "
+        ("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+         "./black_box.py "
          "-x~uniform(-10,10) -z~-").format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=8".format(branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=-8".format(branch=branch).split(" "))
@@ -139,7 +145,8 @@ def init_full_x_remove_z_default_4(init_full_x_rename_y_z):
     name = "full_x_rename_y_z"
     branch = "full_x_remove_z_default_4"
     orion.core.cli.main(
-        ("init_only -n {branch} --branch-from {name} ./black_box.py "
+        ("init_only -n {branch} --branch-from {name} --cli-change-type noeffect "
+         "./black_box.py "
          "-x~uniform(-10,10) -z~-4").format(name=name, branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=9".format(branch=branch).split(" "))
     orion.core.cli.main("insert -n {branch} script -x=-9".format(branch=branch).split(" "))
@@ -173,10 +180,15 @@ def init_full_x_new_cli(init_full_x):
 @pytest.fixture
 def init_full_x_ignore_cli(init_full_x):
     """Use the --non-monitored-arguments argument"""
-    name = "full_x"
+    name = "full_x_with_new_opt"
+    orion.core.cli.main(("init_only -n {name} --config orion_config.yaml ./black_box_new.py "
+                         "-x~uniform(-10,10)").format(name=name).split(" "))
+    orion.core.cli.main("insert -n {name} script -x=0".format(name=name).split(" "))
+
     orion.core.cli.main(
-        ("init_only -n {name} --non-monitored-arguments a-new --cli-change-type noeffect "
-         "./black_box_new.py -x~uniform(-10,10) --a-new argument").format(name=name).split(" "))
+        ("init_only -n {name} --non-monitored-arguments a-new "
+         "--config orion_config.yaml ./black_box_new.py "
+         "-x~uniform(-10,10) --a-new argument").format(name=name).split(" "))
     orion.core.cli.main("insert -n {name} script -x=1.2".format(name=name).split(" "))
     orion.core.cli.main("insert -n {name} script -x=-1.2".format(name=name).split(" "))
 

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -42,7 +42,7 @@ def test_demo_with_default_algo_cli_config_only(database, monkeypatch):
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']
     assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['-x~uniform(-50, 50)']
+    assert exp['metadata']['user_args'] == ["./black_box.py", '-x~uniform(-50, 50)']
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -52,6 +52,7 @@ def test_demo(database, monkeypatch):
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
 
     user_args = [
+        "./black_box.py",
         "-x~uniform(-50, 50, precision=None)",
         "--test-env",
         "--experiment-id", '{exp.id}',
@@ -61,7 +62,7 @@ def test_demo(database, monkeypatch):
         "--working-dir", '{trial.working_dir}']
 
     orion.core.cli.main([
-        "hunt", "--config", "./orion_config.yaml", "./black_box.py"] + user_args)
+        "hunt", "--config", "./orion_config.yaml"] + user_args)
 
     exp = list(database.experiments.find({'name': 'voila_voici'}))
     assert len(exp) == 1
@@ -120,7 +121,8 @@ def test_demo_with_script_config(database, monkeypatch):
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']
     assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['--config', 'script_config.yaml']
+    assert exp['metadata']['user_args'] == ['./black_box_w_config.py', '--config',
+                                            'script_config.yaml']
 
     trials = list(database.trials.find({'experiment': exp_id}))
     assert len(trials) <= 15
@@ -148,7 +150,7 @@ def test_demo_with_python_and_script(database, monkeypatch):
     """Test a simple usage scenario."""
     monkeypatch.chdir(os.path.dirname(os.path.abspath(__file__)))
     orion.core.cli.main(["hunt", "--config", "./orion_config.yaml",
-                         "python", "./black_box_w_config.py", "--config", "script_config.yaml"])
+                         "python", "black_box_w_config.py", "--config", "script_config.yaml"])
 
     exp = list(database.experiments.find({'name': 'voila_voici'}))
     assert len(exp) == 1
@@ -164,7 +166,7 @@ def test_demo_with_python_and_script(database, monkeypatch):
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']
     assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['./black_box_w_config.py',
+    assert exp['metadata']['user_args'] == ['python', 'black_box_w_config.py',
                                             '--config', 'script_config.yaml']
 
     trials = list(database.trials.find({'experiment': exp_id}))
@@ -216,7 +218,7 @@ def test_demo_two_workers(database, monkeypatch):
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']
     assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['-x~norm(34, 3)']
+    assert exp['metadata']['user_args'] == ['./black_box.py', '-x~norm(34, 3)']
 
     trials = list(database.trials.find({'experiment': exp_id}))
     status = defaultdict(int)
@@ -264,7 +266,7 @@ def test_workon():
         assert 'user' in exp['metadata']
         assert 'datetime' in exp['metadata']
         assert 'user_script' in exp['metadata']
-        assert exp['metadata']['user_args'] == ['-x~uniform(-50, 50, precision=None)']
+        assert exp['metadata']['user_args'] == config['user_args']
 
         trials = list(storage.fetch_trials(experiment))
         assert len(trials) <= 15
@@ -555,7 +557,8 @@ def test_demo_with_nondefault_config_keyword(database, monkeypatch):
     assert 'datetime' in exp['metadata']
     assert 'orion_version' in exp['metadata']
     assert 'user_script' in exp['metadata']
-    assert exp['metadata']['user_args'] == ['--configuration', 'script_config.yaml']
+    assert exp['metadata']['user_args'] == ['./black_box_w_config_other.py', '--configuration',
+                                            'script_config.yaml']
 
     trials = list(database.trials.find({'experiment': exp_id}))
     assert len(trials) <= 15

--- a/tests/unittests/core/cli/test_info.py
+++ b/tests/unittests/core/cli/test_info.py
@@ -422,15 +422,15 @@ bayesianoptimizer:
 def test_format_space():
     """Test space section formatting"""
     experiment = DummyExperiment()
-    commandline = ['executing.sh', '--some~choices(["random", "or", "not"])',
-                   '--command~uniform(0, 1)']
-    space = SpaceBuilder().build_from(commandline)
+    space = SpaceBuilder().build(
+        {"some": 'choices(["random", "or", "not"])',
+         "command": 'uniform(0, 1)'})
     experiment.space = space
     assert format_space(experiment) == """\
 Space
 =====
-/command: uniform(0, 1)
-/some: choices(['random', 'or', 'not'])
+command: uniform(0, 1)
+some: choices(['random', 'or', 'not'])
 """
 
 
@@ -576,7 +576,9 @@ def test_format_info(algorithm_dict, dummy_trial):
     experiment.max_trials = 100
     experiment.configuration = {'algorithms': algorithm_dict}
 
-    space = SpaceBuilder().build_from(commandline)
+    space = SpaceBuilder().build(
+        {"some": 'choices(["random", "or", "not"])',
+         "command": 'uniform(0, 1)'})
     experiment.space = space
     experiment.metadata.update(dict(
         user='user',
@@ -648,8 +650,8 @@ bayesianoptimizer:
 
 Space
 =====
-/command: uniform(0, 1)
-/some: choices(['random', 'or', 'not'])
+command: uniform(0, 1)
+some: choices(['random', 'or', 'not'])
 
 
 Meta-data

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -210,14 +210,15 @@ def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_inst
 @pytest.fixture
 def new_config():
     """Generate a new experiment configuration"""
+    user_script = 'abs_path/black_box.py'
     config = dict(
         name='test',
         algorithms='fancy',
         version=1,
         metadata={'VCS': 'to be changed',
-                  'user_script': 'abs_path/black_box.py',
-                  'user_args':
-                  ['--new~normal(0,2)', '--changed~normal(0,2)'],
+                  'user_script': user_script,
+                  'user_args': [
+                      user_script, '--new~normal(0,2)', '--changed~normal(0,2)'],
                   'user': 'some_user_name'})
 
     backward.populate_space(config)
@@ -228,6 +229,7 @@ def new_config():
 @pytest.fixture
 def old_config(create_db_instance):
     """Generate an old experiment configuration"""
+    user_script = 'abs_path/black_box.py'
     config = dict(
         name='test',
         algorithms='random',
@@ -238,9 +240,9 @@ def old_config(create_db_instance):
                           "active_branch": None,
                           "diff_sha": "diff",
                           },
-                  'user_script': 'abs_path/black_box.py',
-                  'user_args':
-                  ['--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
+                  'user_script': user_script,
+                  'user_args': [
+                      user_script, '--missing~uniform(-10,10)', '--changed~uniform(-10,10)'],
                   'user': 'some_user_name'})
 
     backward.populate_space(config)

--- a/tests/unittests/core/evc/test_conflicts.py
+++ b/tests/unittests/core/evc/test_conflicts.py
@@ -285,7 +285,9 @@ class TestCommandLineConflict(object):
     def test_repr(self, cli_conflict):
         """Verify the representation of conflict for user interface"""
         assert (
-            repr(cli_conflict) == "Old arguments '' != new arguments 'bool-arg True some-new args'")
+            repr(cli_conflict) == (
+                "Old arguments '_pos_0 abs_path/black_box.py' != "
+                "new arguments '_pos_0 abs_path/black_box.py bool-arg True some-new args'"))
 
 
 class TestScriptConfigConflict(object):

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -72,7 +72,7 @@ def new_config(random_dt, script_path):
                   'orion_version': 'XYZ',
                   'user_script': script_path,
                   'user_config': 'abs_path/hereitis.yaml',
-                  'user_args': ['--mini-batch~uniform(32, 256, discrete=True)'],
+                  'user_args': [script_path, '--mini-batch~uniform(32, 256, discrete=True)'],
                   'VCS': {"type": "git",
                           "is_dirty": False,
                           "HEAD_sha": "test",
@@ -249,7 +249,7 @@ def test_build_from_args_no_hit(config_file, random_dt, script_path, new_config)
     assert exp.metadata['datetime'] == random_dt
     assert exp.metadata['user'] == 'dendi'
     assert exp.metadata['user_script'] == cmdargs['user_args'][0]
-    assert exp.metadata['user_args'] == cmdargs['user_args'][1:]
+    assert exp.metadata['user_args'] == cmdargs['user_args']
     assert exp.pool_size == 1
     assert exp.max_trials == 100
     assert exp.algorithms.configuration == {'random': {'seed': None}}
@@ -271,6 +271,7 @@ def test_build_from_args_hit(old_config_file, script_path, new_config):
 
     assert exp._id == new_config['_id']
     assert exp.name == new_config['name']
+    assert exp.version == 1
     assert exp.configuration['refers'] == new_config['refers']
     assert exp.metadata == new_config['metadata']
     assert exp.max_trials == new_config['max_trials']

--- a/tests/unittests/core/io/test_orion_cmdline_parser.py
+++ b/tests/unittests/core/io/test_orion_cmdline_parser.py
@@ -10,13 +10,13 @@ from orion.core.worker.trial import Trial
 @pytest.fixture
 def parser():
     """Return an instance of `OrionCmdlineParser`."""
-    return OrionCmdlineParser()
+    return OrionCmdlineParser(allow_non_existing_user_script=True)
 
 
 @pytest.fixture
 def parser_diff_prefix():
     """Return an instance of `OrionCmdlineParser` with a different config prefix."""
-    return OrionCmdlineParser(config_prefix='config2')
+    return OrionCmdlineParser(config_prefix='config2', allow_non_existing_user_script=True)
 
 
 @pytest.fixture
@@ -91,11 +91,11 @@ def test_parse_from_unknown_config(parser, some_sample_config):
 
 def test_parse_equivalency(yaml_config, json_config):
     """Templates found from json and yaml are the same."""
-    parser_yaml = OrionCmdlineParser()
+    parser_yaml = OrionCmdlineParser(allow_non_existing_user_script=True)
     parser_yaml.parse(yaml_config)
     dict_from_yaml = parser_yaml.config_file_data
 
-    parser_json = OrionCmdlineParser()
+    parser_json = OrionCmdlineParser(allow_non_existing_user_script=True)
     parser_json.parse(json_config)
     dict_from_json = parser_json.config_file_data
     assert dict_from_json == dict_from_yaml
@@ -249,10 +249,8 @@ def test_configurable_config_arg(parser_diff_prefix, yaml_sample_path):
     assert '/something-same' in config
 
 
-def test_get_state_dict_before_parse(commandline):
+def test_get_state_dict_before_parse(parser, commandline):
     """Test getting state dict."""
-    parser = OrionCmdlineParser()
-
     assert parser.get_state_dict() == {
         'parser': {
             'arguments': [],
@@ -265,10 +263,8 @@ def test_get_state_dict_before_parse(commandline):
         'converter': None}
 
 
-def test_get_state_dict_after_parse_no_config_file(commandline):
+def test_get_state_dict_after_parse_no_config_file(parser, commandline):
     """Test getting state dict."""
-    parser = OrionCmdlineParser()
-
     parser.parse(commandline)
 
     assert parser.get_state_dict() == {
@@ -281,10 +277,8 @@ def test_get_state_dict_after_parse_no_config_file(commandline):
         'converter': None}
 
 
-def test_get_state_dict_after_parse_with_config_file(yaml_config, commandline):
+def test_get_state_dict_after_parse_with_config_file(parser, yaml_config, commandline):
     """Test getting state dict."""
-    parser = OrionCmdlineParser()
-
     cmd_args = yaml_config
     cmd_args.extend(commandline)
 
@@ -310,7 +304,7 @@ def test_set_state_dict(parser, commandline, json_config, tmpdir, json_converter
     state = parser.get_state_dict()
     parser = None
 
-    blank_parser = OrionCmdlineParser()
+    blank_parser = OrionCmdlineParser(allow_non_existing_user_script=True)
 
     blank_parser.set_state_dict(state)
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -93,6 +93,12 @@ def test_fetch_metadata_non_executable_users_script():
     assert metadata['user_script'] == script_path
 
 
+def test_fetch_metadata_python_users_script(script_path):
+    """Verify user script is correctly infered if called with python"""
+    metadata = resolve_config.fetch_metadata(user_args=['python', script_path, 'some', 'args'])
+    assert metadata['user_script'] == script_path
+
+
 def test_fetch_metadata_not_existed_path():
     """Verfiy the raise of error when user_script path does not exist"""
     path = 'dummy/path'
@@ -107,7 +113,7 @@ def test_fetch_metadata_user_args(script_path):
     user_args = [os.path.abspath(script_path)] + list(map(str, range(10)))
     metadata = resolve_config.fetch_metadata(user_args=user_args)
     assert metadata['user_script'] == user_args[0]
-    assert metadata['user_args'] == user_args[1:]
+    assert metadata['user_args'] == user_args
 
 
 @pytest.mark.usefixtures("with_user_tsirif")

--- a/tests/unittests/core/io/test_space_builder.py
+++ b/tests/unittests/core/io/test_space_builder.py
@@ -203,14 +203,6 @@ class TestDimensionBuilder(object):
 class TestSpaceBuilder(object):
     """Check whether space definition from various input format is successful."""
 
-    def test_build_with_nothing(self, spacebuilder):
-        """Return an empty space if nothing is provided."""
-        space = spacebuilder.build_from([])
-        assert not space
-
-        space = spacebuilder.build_from(["--seed=555", "--naedw"])
-        assert not space
-
     def test_configuration_rebuild(self, spacebuilder):
         """Test that configuration can be used to recreate a space."""
         prior = {'x': 'uniform(0, 10, discrete=True)',

--- a/tests/unittests/core/test_insert.py
+++ b/tests/unittests/core/test_insert.py
@@ -12,24 +12,24 @@ from orion.core.io.space_builder import SpaceBuilder
 @pytest.fixture()
 def real_space():
     """Fixture for real space"""
-    return SpaceBuilder().build_from(["-x~uniform(-10,20)"])
+    return SpaceBuilder().build({"x": "uniform(-10,20)"})
 
 
 @pytest.fixture()
 def integer_space():
     """Fixture for integer space"""
-    return SpaceBuilder().build_from(["-x~uniform(-10,20,discrete=True)"])
+    return SpaceBuilder().build({"x": "uniform(-10,20,discrete=True)"})
 
 
 @pytest.fixture()
 def categorical_space():
     """Fixture for categorical space"""
-    return SpaceBuilder().build_from(["-x~choices([10.1,11,'12','string'])"])
+    return SpaceBuilder().build({"x": "choices([10.1,11,'12','string'])"})
 
 
 def test_validate_input_value_real_real(real_space):
     """Test if real value passed to real space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
     is_valid, casted_value = _validate_input_value("10.0", real_space, namespace)
     assert is_valid
     assert isinstance(casted_value, numbers.Number)
@@ -37,7 +37,7 @@ def test_validate_input_value_real_real(real_space):
 
 def test_validate_input_value_real_integer(real_space):
     """Test if integer value passed to real space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
     is_valid, casted_value = _validate_input_value("10", real_space, namespace)
     assert is_valid
     assert isinstance(casted_value, numbers.Number)
@@ -45,14 +45,14 @@ def test_validate_input_value_real_integer(real_space):
 
 def test_validate_input_value_real_string(real_space):
     """Test if string value passed to real space is rejected properly"""
-    namespace = '/x'
+    namespace = 'x'
     is_valid, casted_value = _validate_input_value("string", real_space, namespace)
     assert not is_valid
 
 
 def test_validate_input_value_real_out_of_bound(real_space):
     """Test if out of bound values passed to real space are rejected properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("100.0", real_space, namespace)
     assert not is_valid
@@ -63,7 +63,7 @@ def test_validate_input_value_real_out_of_bound(real_space):
 
 def test_validate_input_value_integer_real(integer_space):
     """Test if real value passed to integer space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("10.0", integer_space, namespace)
     assert is_valid
@@ -72,7 +72,7 @@ def test_validate_input_value_integer_real(integer_space):
 
 def test_validate_input_value_integer_integer(integer_space):
     """Test if integer value passed to integer space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("10", integer_space, namespace)
     assert is_valid
@@ -81,7 +81,7 @@ def test_validate_input_value_integer_integer(integer_space):
 
 def test_validate_input_value_integer_string(integer_space):
     """Test if string value passed to integer space is rejected properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("string", integer_space, namespace)
     assert not is_valid
@@ -89,7 +89,7 @@ def test_validate_input_value_integer_string(integer_space):
 
 def test_validate_input_value_integer_out_of_bound(integer_space):
     """Test if out of bound values passed to integer space are rejected properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("100.0", integer_space, namespace)
     assert not is_valid
@@ -100,7 +100,7 @@ def test_validate_input_value_integer_out_of_bound(integer_space):
 
 def test_validate_input_value_categorical_real_hit(categorical_space):
     """Test if real value passed to categorical space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("10.1", categorical_space, namespace)
     assert is_valid
@@ -109,7 +109,7 @@ def test_validate_input_value_categorical_real_hit(categorical_space):
 
 def test_validate_input_value_categorical_real_nohit(categorical_space):
     """Test if bad real value passed to categorical space is rejected properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("10", categorical_space, namespace)
     assert not is_valid
@@ -123,7 +123,7 @@ def test_validate_input_value_categorical_real_nohit(categorical_space):
 
 def test_validate_input_value_categorical_integer_hit(categorical_space):
     """Test if integer value passed to categorical space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("11", categorical_space, namespace)
     assert is_valid
@@ -136,7 +136,7 @@ def test_validate_input_value_categorical_integer_hit(categorical_space):
 
 def test_validate_input_value_categorical_integer_nohit(categorical_space):
     """Test if bad integer value passed to categorical space is rejected properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("15", categorical_space, namespace)
     assert not is_valid
@@ -144,7 +144,7 @@ def test_validate_input_value_categorical_integer_nohit(categorical_space):
 
 def test_validate_input_value_categorical_string_number(categorical_space):
     """Test if string number value passed to categorical space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     # Make sure integer 12 does not pass
     is_valid, casted_value = _validate_input_value("12", categorical_space, namespace)
@@ -158,7 +158,7 @@ def test_validate_input_value_categorical_string_number(categorical_space):
 
 def test_validate_input_value_categorical_string_value(categorical_space):
     """Test if literal string value passed to categorical space is validated properly"""
-    namespace = '/x'
+    namespace = 'x'
 
     is_valid, casted_value = _validate_input_value("random", categorical_space, namespace)
     assert not is_valid


### PR DESCRIPTION
## Move user script inference to OrionCmdlineParser

Why:

The commandline parser is responsible of parsing the commandline (duh)
and thus should also have the responsibility of inferring what the user
script is in the given commandline. The repository check still remains
in resolve_config as this is not specific to commandline parsing. This
enables more complex parsing and reuse of templates to keep original
positions in the commandline (previously it was assumed the script would
be at first position in the commandline).

How:

Infer user script during parsing of commandline and save it as an
attribute of the parser. The `user_args` now keeps the `user_script`
within it, we can't simply pop out the first item anymore. The
`user_script`, if found, is then used outside of the parser to detect
a VCS.

## Adapt to new user script inference

Why:

The modification to support more complex inference of user script fixed
a bug that went unnoticed in the functional tests for branching.
The modification of the user script name, which should be detected as a
change in the commandline call, was not detected because it was popped
out of `user_args`. With the modification it was not properly detected,
making plenty of tests fail because they were unfortunately relying on
the bug.

How:

Add --cli-change-type noeffect to let the EVC flow even though there are
changes in the commandline calls (the bug was implicitly doing this).

The test for --non-monitoring-arg was not suppose to lead to any version
change, because the commandline should not be detected as different.
Thus, in this case we remove --cli-change-type noeffect.